### PR TITLE
Properly name the Z object

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -1,6 +1,6 @@
-import { zObject } from "zapier-platform-core";
+import { ZObject } from "zapier-platform-core";
 
-const test = async (z: zObject /*, bundle*/) => {
+const test = async (z: ZObject /*, bundle*/) => {
   // Normally you want to make a request to an endpoint that is either specifically designed to test auth, or one that
   // every user will have access to, such as an account or profile endpoint like /me.
   // In this example, we'll hit httpbin, which validates the Authorization Header against the arguments passed in the URL path

--- a/src/resources/recipe.ts
+++ b/src/resources/recipe.ts
@@ -1,15 +1,15 @@
-import { zObject, Bundle } from "zapier-platform-core";
+import { ZObject, Bundle } from "zapier-platform-core";
 
 const _sharedBaseUrl = "https://auth-json-server.zapier.ninja";
 
-const getRecipe = async (z: zObject, bundle: Bundle) => {
+const getRecipe = async (z: ZObject, bundle: Bundle) => {
   const response = await z.request({
     url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`
   });
   return z.JSON.parse(response.content);
 };
 
-const listRecipes = async (z: zObject, bundle: Bundle) => {
+const listRecipes = async (z: ZObject, bundle: Bundle) => {
   const response = await z.request({
     url: _sharedBaseUrl + "/recipes",
     params: {
@@ -19,7 +19,7 @@ const listRecipes = async (z: zObject, bundle: Bundle) => {
   return z.JSON.parse(response.content);
 };
 
-const createRecipe = async (z: zObject, bundle: Bundle) => {
+const createRecipe = async (z: ZObject, bundle: Bundle) => {
   const response = await z.request({
     url: _sharedBaseUrl + "/recipes",
     method: "POST",
@@ -35,7 +35,7 @@ const createRecipe = async (z: zObject, bundle: Bundle) => {
   return z.JSON.parse(response.content);
 };
 
-const searchRecipe = async (z: zObject, bundle: Bundle) => {
+const searchRecipe = async (z: ZObject, bundle: Bundle) => {
   const response = await z.request({
     url: _sharedBaseUrl + "/recipes",
     params: {


### PR DESCRIPTION
`zapier-platform-core` exposes the capitalised [`ZObject`,](https://github.com/zapier/zapier-platform-core/blob/master/index.d.ts#L104) so the example did not compile correctly. 