### PR TITLE
add typing for input and add some docs

### DIFF
--- a/src/resources/recipe.ts
+++ b/src/resources/recipe.ts
@@ -2,14 +2,16 @@ import { ZObject, Bundle } from "zapier-platform-core";
 
 const _sharedBaseUrl = "https://auth-json-server.zapier.ninja";
 
-const getRecipe = async (z: ZObject, bundle: Bundle) => {
+// you can optionally add add the shape of the inputData in bundle, which will pass that
+//   info down into the function and tests
+const getRecipe = async (z: ZObject, bundle: Bundle<{ id: string }>) => {
   const response = await z.request({
     url: `${_sharedBaseUrl}/recipes/${bundle.inputData.id}`
   });
   return z.JSON.parse(response.content);
 };
 
-const listRecipes = async (z: ZObject, bundle: Bundle) => {
+const listRecipes = async (z: ZObject, bundle: Bundle<{ style?: string }>) => {
   const response = await z.request({
     url: _sharedBaseUrl + "/recipes",
     params: {
@@ -19,7 +21,15 @@ const listRecipes = async (z: ZObject, bundle: Bundle) => {
   return z.JSON.parse(response.content);
 };
 
-const createRecipe = async (z: ZObject, bundle: Bundle) => {
+const createRecipe = async (
+  z: ZObject,
+  bundle: Bundle<{
+    name: string;
+    directions: string;
+    authorId: number;
+    style?: string;
+  }>
+) => {
   const response = await z.request({
     url: _sharedBaseUrl + "/recipes",
     method: "POST",
@@ -69,6 +79,8 @@ const Recipe = {
   // The get method is used by Zapier to fetch a complete representation of a record. This is helpful when the HTTP
   // response from a create call only return an ID, or a search that only returns a minimuml representation of the
   // record. Zapier will follow these up with the get() to retrieve the entire object.
+
+  // You can delete this property if all your calls return the full object
   get: {
     display: {
       label: "Get Recipe",
@@ -76,8 +88,7 @@ const Recipe = {
     },
     operation: {
       inputFields: [{ key: "id", required: true }],
-      perform: getRecipe,
-      sample
+      perform: getRecipe
     }
   },
   // The list method on this resource becomes a Trigger on the app. Zapier will use polling to watch for new records
@@ -94,8 +105,7 @@ const Recipe = {
           helpText: "Explain what style of cuisine this is."
         }
       ],
-      perform: listRecipes,
-      sample
+      perform: listRecipes
     }
   },
   // If your app supports webhooks, you can define a hook method instead of a list method.
@@ -132,8 +142,7 @@ const Recipe = {
           helpText: "Explain what style of cuisine this is."
         }
       ],
-      perform: createRecipe,
-      sample
+      perform: createRecipe
     }
   },
   // The search method on this resource becomes a Search on this app
@@ -144,8 +153,7 @@ const Recipe = {
     },
     operation: {
       inputFields: [{ key: "name", required: true, type: "string" }],
-      perform: searchRecipe,
-      sample
+      perform: searchRecipe
     }
   },
 


### PR DESCRIPTION
Some minor changes I noticed while actually using this:

* we don't need sample on each resource method, since resources do that automatically
* added a little docs
* (the important one) improve example with type of bundle, which is my favorite TS feature of core

before: ![](https://zappy.zapier.com/807A279B-DDD7-4E79-8F03-4F00C2FFBAF7.png)
after: ![](https://zappy.zapier.com/D30333BE-6D1A-44BF-B1FF-8326AB173D69.png)

It also will flag if your `bundle.inputData` is malformed in tests, which is great when users forget to make a well-formed bundle. Examples are from a different app, but illustrate the point

![](https://zappy.zapier.com/6C2586F3-E1A7-43AD-88B0-713D86DAC202.png)

![](https://zappy.zapier.com/86DE44CA-B3C9-4750-9A7E-15AB026892C4.png)